### PR TITLE
Menu links break when APP_URL doesn’t include port and Readme update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,21 @@
+   # App settings
    APP_NAME=Aseer
    APP_ENV=local
    APP_KEY=base64:LBGs6Z9BMYP/nblpiA/KaoDg4DYX/vh+hgCmjuFDXDo=
    APP_DEBUG=true
    APP_URL=http://localhost
    
+   
+   # SQLITE
    DB_CONNECTION=sqlite
+   
+   # MYSQL
    # DB_HOST=127.0.0.1
    # DB_PORT=3306
    # DB_DATABASE=aseer
-   # DB_USERNAME=root
-   # DB_PASSWORD=
+   # DB_USERNAME=root.    #<-----change me
+   # DB_PASSWORD=password #<---change me 
    
+   # Credentials
    DEFAULT_EMAIL="admin@admin.com"
    DEFAULT_PASSWORD="password"

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
    APP_ENV=local
    APP_KEY=base64:LBGs6Z9BMYP/nblpiA/KaoDg4DYX/vh+hgCmjuFDXDo=
    APP_DEBUG=true
-   APP_URL=http://localhost
+   APP_URL=http://localhost:8000/
    
    
    # SQLITE

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+   APP_NAME=Aseer
+   APP_ENV=local
+   APP_KEY=base64:LBGs6Z9BMYP/nblpiA/KaoDg4DYX/vh+hgCmjuFDXDo=
+   APP_DEBUG=true
+   APP_URL=http://localhost
+   
+   DB_CONNECTION=sqlite
+   # DB_HOST=127.0.0.1
+   # DB_PORT=3306
+   # DB_DATABASE=aseer
+   # DB_USERNAME=root
+   # DB_PASSWORD=
+   
+   DEFAULT_EMAIL="admin@admin.com"
+   DEFAULT_PASSWORD="password"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,77 @@ Live [Aseer Platform](https://aseer.net/)
 
 ### How to setup
 
+### macOS Setup Instructions
+
+If you're setting up the Aseer Platform on macOS, follow these steps to install the required tools:
+
+#### SQLite Setup (For Quick Testing)
+
+```bash
+brew install php composer mysql php-imagick
+pecl install imagick
+```
+
+1. create .env file with SQLite configuration (Update the .env file with appropriate connection settings):
+
+```bash
+cp .env.example .env and ```
+
+2.  Create SQLite database file
+
+```bash
+touch database/database.sqlite
+```
+
+3. Generate application key (if not already set) and storage symlink:
+
+```bash
+php artisan key:generate
+php artisan storage:link
+```
+
+4. Run database migrations and seed the database 
+
+```bash
+php artisan migrate
+php artisan db:seed --class=SettingsSeeder
+php artisan db:seed --class=UsersSeeder
+php artisan db:seed --class=PagesSeeder
+php artisan db:seed --class=MenusSeeder
+php artisan db:seed --class=PermissionsSeeder
+php artisan db:seed --class=AttachSuperAdminPermissions
+php artisan db:seed --class=DetaineeSeeder
+php artisan db:seed --class=DetaineePermissionsSeeder
+```
+
+5. Start the development server
+
+```bash
+php artisan serve
+```
+
+### MySQL Setup (For Production)
+
+1. Start MySQL 
+
+```bash
+brew services start mysql
+```
+
+2. Configure .env for MySQL - Update the .env file with appropriate connection settings:
+
+```bash
+cp .env.example .env and ```
+
+3. Create the database 
+
+```bash
+mysql -u root -p -e "CREATE DATABASE aseer CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+```
+
+### Ubuntu/Debian Linux Setup Instructions
+
 ```bash
 #dont forget to install 
 sudo apt-get install php-imagick
@@ -71,6 +142,7 @@ php artisan db:seed
 php artisan queue:work
 php artisan schedule:work 
 ```
+
 
 ### Credentials
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ php artisan db:seed
 # don't forget to start queuing and run schedule on the background 
 php artisan queue:work
 php artisan schedule:work 
+php artisan menu:update-links
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ brew services start mysql
 2. Configure .env for MySQL - Update the .env file with appropriate connection settings:
 
 ```bash
-cp .env.example .env and ```
+cp .env.example .env and 
+```
 
 3. Create the database 
 
 ```bash
 mysql -u root -p -e "CREATE DATABASE aseer CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-
 ```
 
 ### Ubuntu/Debian Linux Setup Instructions

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ pecl install imagick
 1. create .env file with SQLite configuration (Update the .env file with appropriate connection settings):
 
 ```bash
-cp .env.example .env and ```
+cp .env.example .env and
+```
 
 2.  Create SQLite database file
 
@@ -107,7 +108,7 @@ php artisan serve
 
 1. Start MySQL 
 
-```bash
+```
 brew services start mysql
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,15 +87,10 @@ php artisan storage:link
 4. Run database migrations and seed the database 
 
 ```bash
-php artisan migrate
-php artisan db:seed --class=SettingsSeeder
-php artisan db:seed --class=UsersSeeder
-php artisan db:seed --class=PagesSeeder
-php artisan db:seed --class=MenusSeeder
-php artisan db:seed --class=PermissionsSeeder
-php artisan db:seed --class=AttachSuperAdminPermissions
-php artisan db:seed --class=DetaineeSeeder
-php artisan db:seed --class=DetaineePermissionsSeeder
+
+php artisan migrate:fresh
+php artisan db:seed
+
 ```
 
 5. Start the development server

--- a/app/Console/Commands/UpdateMenuLinksUrls.php
+++ b/app/Console/Commands/UpdateMenuLinksUrls.php
@@ -49,8 +49,8 @@ class UpdateMenuLinksUrls extends Command
             
             // Special handling for custom links that might be hardcoded
             if ($link->type == "CUSTOM_LINK") {
-                // If it's the home page using APP_URL
-                if ($oldUrl == env('APP_URL')) {
+                // If it's the home page using APP_URL or just http://localhost
+                if ($oldUrl == env('APP_URL') || $oldUrl == 'http://localhost' || $link->title == 'الرئيسية') {
                     $link->url = url('/');
                     $link->save();
                     $count++;

--- a/app/Console/Commands/UpdateMenuLinksUrls.php
+++ b/app/Console/Commands/UpdateMenuLinksUrls.php
@@ -46,12 +46,48 @@ class UpdateMenuLinksUrls extends Command
         
         foreach ($menuLinks as $link) {
             $oldUrl = $link->url;
-            $newUrl = MainHelper::menuLinkGenerator($link);
             
-            if ($oldUrl !== $newUrl) {
-                $link->update(['url' => $newUrl]);
-                $count++;
-                $this->line("Updated link: {$link->title} - {$oldUrl} -> {$newUrl}");
+            // Special handling for custom links that might be hardcoded
+            if ($link->type == "CUSTOM_LINK") {
+                // If it's the home page using APP_URL
+                if ($oldUrl == env('APP_URL')) {
+                    $link->url = url('/');
+                    $link->save();
+                    $count++;
+                    $this->line("Updated home link: {$link->title} - {$oldUrl} -> {$link->url}");
+                }
+                // If it's a blog link
+                elseif (strpos($oldUrl, '/blog') !== false) {
+                    $link->url = route('blog');
+                    $link->save();
+                    $count++;
+                    $this->line("Updated blog link: {$link->title} - {$oldUrl} -> {$link->url}");
+                }
+                // If it's a contact link
+                elseif (strpos($oldUrl, '/contact') !== false) {
+                    $link->url = route('contact');
+                    $link->save();
+                    $count++;
+                    $this->line("Updated contact link: {$link->title} - {$oldUrl} -> {$link->url}");
+                }
+                // For other custom links, use the menuLinkGenerator
+                else {
+                    $newUrl = MainHelper::menuLinkGenerator($link);
+                    if ($oldUrl !== $newUrl) {
+                        $link->update(['url' => $newUrl]);
+                        $count++;
+                        $this->line("Updated link: {$link->title} - {$oldUrl} -> {$newUrl}");
+                    }
+                }
+            } 
+            // For PAGE and CATEGORY links
+            else {
+                $newUrl = MainHelper::menuLinkGenerator($link);
+                if ($oldUrl !== $newUrl) {
+                    $link->update(['url' => $newUrl]);
+                    $count++;
+                    $this->line("Updated link: {$link->title} - {$oldUrl} -> {$newUrl}");
+                }
             }
         }
         

--- a/app/Console/Commands/UpdateMenuLinksUrls.php
+++ b/app/Console/Commands/UpdateMenuLinksUrls.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\MenuLink;
+use App\Helpers\MainHelper;
+
+class UpdateMenuLinksUrls extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'menu:update-links';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update all menu links to use the correct URL format';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->info('Updating menu links...');
+        
+        $menuLinks = MenuLink::all();
+        $count = 0;
+        
+        foreach ($menuLinks as $link) {
+            $oldUrl = $link->url;
+            $newUrl = MainHelper::menuLinkGenerator($link);
+            
+            if ($oldUrl !== $newUrl) {
+                $link->update(['url' => $newUrl]);
+                $count++;
+                $this->line("Updated link: {$link->title} - {$oldUrl} -> {$newUrl}");
+            }
+        }
+        
+        $this->info("Updated {$count} menu links successfully.");
+        return 0;
+    }
+} 

--- a/app/Helpers/MainHelper.php
+++ b/app/Helpers/MainHelper.php
@@ -196,16 +196,25 @@ class MainHelper
     public static function menuLinkGenerator(MenuLink $link)
     {
         if ($link->type == "CUSTOM_LINK") {
-            return $link->url;
+            #return $link->url;
+            if (filter_var($link->url, FILTER_VALIDATE_URL)) {
+                return $link->url;
+            }
+            if (str_starts_with($link->url, '/')) {
+                return url($link->url);
+            }
+            return url($link->url);            
         } elseif ($link->type == "PAGE") {
             $page = \App\Models\Page::where('id', $link->type_id)->first();
             if ($page == null)
-                return env("APP_URL");
+                #return env("APP_URL");
+                return url('/');
             return route('page.show', $page);
         } elseif ($link->type == "CATEGORY") {
             $category = \App\Models\Category::where('id', $link->type_id)->first();
             if ($category == null)
-                return env("APP_URL");
+                #return env("APP_URL");
+                return url('/');
             return route('category.show', $category);
         }
     }


### PR DESCRIPTION
### Description
Changing `APP_URL` to `http://localhost` without the port causes incorrect menu links when running `php artisan serve`.

### Suggested Fix
Document clearly that after changing `APP_URL` or server port, `php artisan menu:update-links` must be re-run.

### Additional Changes

Added a new section in your README.md,  under “Setup Instructions for MacOS.